### PR TITLE
audren: Accept REV8

### DIFF
--- a/Ryujinx.HLE/HOS/Services/Audio/AudioRendererManager/Types/AudioRendererConsts.cs
+++ b/Ryujinx.HLE/HOS/Services/Audio/AudioRendererManager/Types/AudioRendererConsts.cs
@@ -3,7 +3,7 @@ namespace Ryujinx.HLE.HOS.Services.Audio.AudioRendererManager
     static class AudioRendererConsts
     {
         // Revision Consts
-        public const int Revision  = 7;
+        public const int Revision  = 8;
         public const int Rev0Magic = ('R' << 0) | ('E' << 8) | ('V' << 16) | ('0' << 24);
         public const int RevMagic  = Rev0Magic + (Revision << 24);
 


### PR DESCRIPTION
REV8 only added changes on performance buffer and wavebuffer dsp command
generation.

As we don't support any of those, we can just increment the revision
number for now.

- [ ] 